### PR TITLE
Creating DockerFile according issue #5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.23.2 AS builder
+WORKDIR /app
+
+COPY ./src/go.mod ./
+RUN go mod tidy
+
+COPY ./src /app
+RUN go build -o main ./server
+
+FROM debian:bookworm
+WORKDIR /root/
+
+COPY --from=builder /app/main .
+
+EXPOSE 8080
+CMD ["./main"]


### PR DESCRIPTION
This pull request includes changes to the `Dockerfile` to set up a multi-stage build for a Go application. The most important changes include:

* Added a new stage using the `golang:1.23.2` image to build the Go application.
* Set the working directory to `/app` and copied the `go.mod` file and source code into the container.
* Ran `go mod tidy` to clean up the module dependencies and built the application with `go build`.
* Added a second stage using the `debian:bookworm` image to create a smaller final image containing only the compiled binary.
* Exposed port 8080 and set the command to run the compiled binary.